### PR TITLE
Separating Key Phrases with Commas

### DIFF
--- a/src/bootstrap/js/bootstrap.min.js
+++ b/src/bootstrap/js/bootstrap.min.js
@@ -43,14 +43,27 @@ fileInput.addEventListener('change', handleInputChange);
  var urlParams = new URLSearchParams(queryString);
  var text = urlParams.get('text');
 
- // Split the text into an array using the comma as separator
- var textArray = text.split(', • ');
+//  text.forEach(function(word) {
+//   console.log(word);
+//  });
+
+console.log("Text: " + text);
+
+var textCleanedDots = text.replace(/•/g, '');
+var textCleanedComma = textCleanedDots.replace(/,+/, ',');
+var textArray = textCleanedComma.split(',,');
+textArray.forEach(function (word, index) {
+    textArray[index] = word.replace(/, {1}/, '');
+});
+
+console.log("Text array: " + textArray);
 
  // Populate the list with each word
  var userList = document.getElementById("userText");
  textArray.forEach(function(word) {
    var listItem = document.createElement("li");
    listItem.textContent = word;
+   console.log(listItem.textContent);
    userList.appendChild(listItem);
  });
 

--- a/src/bootstrap/js/bootstrap.min.js
+++ b/src/bootstrap/js/bootstrap.min.js
@@ -36,38 +36,34 @@ const exportButton = document.getElementById('exportbutton');
 
 form.addEventListener('submit', handleSubmit);
 fileInput.addEventListener('change', handleInputChange);
+
  // Get the text from the URL query parameter
-
-
  var queryString = window.location.search;
  var urlParams = new URLSearchParams(queryString);
  var text = urlParams.get('text');
 
-//  text.forEach(function(word) {
-//   console.log(word);
-//  });
-
-console.log("Text: " + text);
-
 var textCleanedDots = text.replace(/•/g, '');
-var textCleanedComma = textCleanedDots.replace(/,+/, ',');
-var textArray = textCleanedComma.split(',,');
+var textArray = textCleanedDots.split(',,');
+
 textArray.forEach(function (word, index) {
-    textArray[index] = word.replace(/, {1}/, '');
+  textArray[index] = word.replace(/,/g, ''); // Removing excess commas
 });
 
-console.log("Text array: " + textArray);
+textArray.forEach(function (word, index) {
+  textArray[index] = word.replace(/ \s+/g, ' '); // Removing excess spaces
+});
+
+textArray.forEach(function (word, index) {
+  textArray[index] = word.trim(); // Trimming each keyword / keyphrase
+});
 
  // Populate the list with each word
  var userList = document.getElementById("userText");
  textArray.forEach(function(word) {
    var listItem = document.createElement("li");
    listItem.textContent = word;
-   console.log(listItem.textContent);
    userList.appendChild(listItem);
  });
-
-
 
 function handleSubmit(event) {
   event.preventDefault();
@@ -218,11 +214,16 @@ function readPDF(file) {
 
       // Split the text into sentences
         // Updated to prevent issues from abbreviations, such as Mr. and Mrs.
-      const sentences = fullText.split(/(?<!\b(?:Mr|Mrs|Ms|Dr)\.)\s*[\.\?!](?=\s*[A-Z])/g);
+        // Updated to split on · and • for bullet pointed lists
+      const sentences = fullText.split(/(?<!\b(?:Mr|Mrs|Ms|Dr)\.)\s*[\.\?!•·](?=\s*[A-Z])/g);
+
+      console.log(keywordList);
 
       // Filter sentences containing keywords
       sentences.forEach((sentence) => {
         const normalizedSentence = sentence.replace(/\s+/g, ' ').trim();
+
+
         if (keywordList.some(keyword => normalizedSentence.toLowerCase().includes(keyword.toLowerCase()))) {
           sentencesWithKeywords.push(normalizedSentence);
         }


### PR DESCRIPTION
# Description

This PR updates the first page of our application by allowing the user to separate the phrases they want to search for based on commas rather than spaces. This allows for more specific searches such as searching for "software process" rather than searching for "software" and "process".

Demo:

https://github.com/NathanWeiland10/MatadorIntelligence/assets/77362517/1039e77c-5055-4e22-9308-ea5a8e673bd4

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Used "software process" for the keyphrases using the 4120 syllabus as a document and got 3 results. I then ran using "software, process", which led to using the keyphrases "software" and "process", which led to 25 results.

# Checklist:

- [X] My code follows the style guidelines of this project (Pep 8)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes - (No unit tests implemented)
- [X] Any dependent changes have been merged and published in downstream modules
